### PR TITLE
Update to monitor Ubuntu24

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -25,7 +25,7 @@ jobs:
       id: get_release
       run: |
         RELEASES=$(curl -s https://api.github.com/repos/actions/runner-images/releases)
-        RELEASE=$(echo "$RELEASES" | jq -r '.[] | select(.prerelease == false) | .tag_name' | sort -r | grep ubuntu22 |head -n1)
+        RELEASE=$(echo "$RELEASES" | jq -r '.[] | select(.prerelease == false) | .tag_name' | sort -r | grep ubuntu24 |head -n1)
         echo "RELEASE_TAG=$RELEASE" >> $GITHUB_OUTPUT
         echo "RELEASE_TAG=$RELEASE"
 


### PR DESCRIPTION
# Description

Our self-hosted runners have been upgraded to ubuntu 24 thus update the workflow to monitor ubuntu24's updated images.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
